### PR TITLE
Fix W3C validator warning: "The type attribute is unnecessary for JavaScript resources"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1151,11 +1151,8 @@
       }
     </script>
 
-    <script
-      type="text/javascript"
-      src="https://www.gstatic.com/charts/loader.js"
-    ></script>
-    <script type="text/javascript">
+    <script src="https://www.gstatic.com/charts/loader.js"></script>
+    <script>
       // These correspond to ACT Health's 7 point scale
       // https://www.health.act.gov.au/about-our-health-system/population-health/environmental-monitoring/monitoring-and-regulating-air-0
       // THRESHOLDS = [


### PR DESCRIPTION
Lots of W3C validator warnings which I will clean up.