### PR TITLE
added auto update to AirRater.org.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1031,7 +1031,8 @@
 
         // in order to not stress out airrater a random amount of time btween 60s to 120s is added.
         let ms_to_next_update = ( next_update - Date.now() ) + randomNumber(60,120) * 1000
-        setTimeout(render_current_aq, ms_to_next_update);
+        // added a minumum delay of 1 minute here as airrater.org does not always update at x:55 exactly.
+        setTimeout(render_current_aq, Math.max(ms_to_next_update, 60*1000));
         draw_graphs();
       }
       // !!window.chrome && render_current_aq();

--- a/index.html
+++ b/index.html
@@ -1023,13 +1023,22 @@
           new Date(last_update),
           false
         );
+        let next_update = last_update + 60 * 60 * 1000
         document.getElementById("next-update").innerHTML = date_format(
-          new Date(last_update + 60 * 60 * 1000),
+          new Date(next_update),
           false
         );
+
+        // in order to not stress out airrater a random amount of time btween 60s to 120s is added.
+        let ms_to_next_update = ( next_update - Date.now() ) + randomNumber(60,120) * 1000
+        setTimeout(render_current_aq, ms_to_next_update);
         draw_graphs();
       }
       // !!window.chrome && render_current_aq();
+      function randomNumber(min, max) {
+        return Math.random() * (max - min) + min;
+      }
+
       render_current_aq();
 
       function aqi_rating(aqi) {


### PR DESCRIPTION
Refreshes air quality data within 1 to 2 minutes of airrater updating. Prevents having the user to manually refresh the page.