### PR TITLE
'Live' updating at 56 past the hour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs/CanberraAir.com/config

--- a/index.html
+++ b/index.html
@@ -1033,15 +1033,15 @@
       render_current_aq();
       
       // Update AQ at 56 past the hour
-      async function job_update_aq()
-      {
+      async function job_update_aq() {
         var mins = new Date().getMinutes();
-        if(mins == "56")
-        {
+        if(mins == "56") {
           render_current_aq();
+          drawAQI();
           await new Promise(r => setTimeout(r, 30000));
         }
       }
+      
       setInterval(job_update_aq, 30000);
 
       function aqi_rating(aqi) {

--- a/index.html
+++ b/index.html
@@ -1031,6 +1031,18 @@
       }
       // !!window.chrome && render_current_aq();
       render_current_aq();
+      
+      // Update AQ at 56 past the hour
+      async function job_update_aq()
+      {
+        var mins = new Date().getMinutes();
+        if(mins == "56")
+        {
+          render_current_aq();
+          await new Promise(r => setTimeout(r, 30000));
+        }
+      }
+      setInterval(job_update_aq, 30000);
 
       function aqi_rating(aqi) {
         if (aqi >= 200) return "Hazardous";


### PR DESCRIPTION
There's a competing approach to the live update here that uses random numbers; I assume here that the time a user arrives sufficiently randomises the timer which checks every 30s to see if it's now 56 past the hour and refreshes the graph and figures at that point. An auto-update may be some combination of approaches.