### PR TITLE
Update index.html to show 6hr as selected graph time

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,18 +372,22 @@
               <h5 class="card-title">
                 Graphs
                 <span class="graph-links"
-                  ><a href="#graphs" onclick="return graphHours(6, this)"
+                  ><a
+                    href="#graphs"
+                    onclick="return graphHours(6, this)"
+                    class="graph-selected"
                     >6hr</a
                   >
                   |
-                  <a href="#graphs" onclick="return graphHours(12, this)"
+                  <a
+                    href="#graphs"
+                    onclick="return graphHours(12, this)"
                     >12hr</a
                   >
                   |
                   <a
                     href="#graphs"
                     onclick="return graphHours(24, this)"
-                    class="graph-selected"
                     >24hr</a
                   >
                 </span>


### PR DESCRIPTION
closes #25 

Elsewhere in the file the graph is set to show 6 hours, but the 24hr button is currently highlighted as selected by default. This resolves that by showing the 6hr button as selected.