### PR TITLE
Fix link to pre-selected graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,6 +373,7 @@
                 Graphs
                 <span class="graph-links"
                   ><a href="#graphs" onclick="return graphHours(6, this)"
+                    class="graph-selected"
                     >6hr</a
                   >
                   |
@@ -383,7 +384,6 @@
                   <a
                     href="#graphs"
                     onclick="return graphHours(24, this)"
-                    class="graph-selected"
                     >24hr</a
                   >
                 </span>


### PR DESCRIPTION
This PR fixes which link is underlined to align with the correct preloaded graph. Previously, it would appear the 24hr plot was selected even though it was the 6hr one. This PR should clear up any confusion.

Cheers!